### PR TITLE
Added a default reputation host

### DIFF
--- a/files/nginx/config/default.conf
+++ b/files/nginx/config/default.conf
@@ -12,4 +12,9 @@ server {
       proxy_pass http://msf;
     }
 
+    location / {
+      proxy_set_header Host "www.stealmylogin.com";
+      proxy_pass http://www.stealmylogin.com;
+    }
+
 }


### PR DESCRIPTION
## About

Adds a default reputation host, this is a host that people browsing your malicious server will see if they do not know the paths you have your tools listening on.